### PR TITLE
feat!: return code with sources

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -69,5 +69,10 @@ export interface LoadConfigOptions<T = any> extends SearchOptions {
 
 export interface LoadConfigResult<T> {
   config: T
-  sources: string[]
+  sources: Source[]
+}
+
+export interface Source {
+  filepath: string
+  source?: string
 }

--- a/test/__snapshots__/run.test.ts.snap
+++ b/test/__snapshots__/run.test.ts.snap
@@ -1,17 +1,58 @@
 // Vitest Snapshot v1
 
-exports[`load > files 1`] = `5`;
-
-exports[`load 1`] = `
+exports[`loads the given sources > config 1`] = `
 {
   "deep": {
     "foo": "you should get this",
   },
   "defaults": "default",
   "from": "package.json",
+  "importValue": "uwu",
   "json": "allo",
   "mjs": "hi",
   "rewrite": "Hi",
   "ts": "hello",
 }
+`;
+
+exports[`loads the given sources > files 1`] = `5`;
+
+exports[`loads the given sources > sources 1`] = `
+[
+  "\\"use strict\\";Object.defineProperty(exports, \\"__esModule\\", { value: true });exports.default = void 0;var _file = require(\\"./file\\");var _default =
+
+{
+  ts: 'hello',
+  deep: {
+    foo: 'you should get this' },
+
+  importValue: _file.value };exports.default = _default;",
+  "\\"use strict\\";Object.defineProperty(exports, \\"__esModule\\", { value: true });exports.default = void 0;var _default = {
+  mjs: 'hi',
+  deep: {
+    foo: 'this should be override' } };exports.default = _default;",
+  "{
+  \\"json\\": \\"allo\\"
+}
+",
+  "{
+  \\"un\\": {
+    \\"from\\": \\"package.json\\"
+  }
+}
+",
+  "\\"use strict\\";Object.defineProperty(exports, \\"__esModule\\", { value: true });exports.default = void 0;
+let __unconfig_data;
+let __unconfig_stub = function (data) {__unconfig_data = data;};
+__unconfig_stub.default = (data) => {__unconfig_data = data;};
+const a = __unconfig_stub;
+
+const __unconfig_default = () => {
+  return a({
+    rewrite: 'Hi' });
+
+};
+
+if (typeof __unconfig_default === \\"function\\") __unconfig_default();var _default = __unconfig_data;exports.default = _default;",
+]
 `;

--- a/test/fixtures/file.ts
+++ b/test/fixtures/file.ts
@@ -1,0 +1,1 @@
+export const value = 'uwu'

--- a/test/fixtures/un.config.ts
+++ b/test/fixtures/un.config.ts
@@ -1,6 +1,9 @@
+import { value } from './file'
+
 export default {
   ts: 'hello',
   deep: {
     foo: 'you should get this',
   },
+  importValue: value,
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -3,7 +3,7 @@ import { expect, it } from 'vitest'
 import { loadConfig } from '../src'
 import { sourcePackageJsonFields, sourcePluginFactory } from '../src/presets'
 
-it('load', async() => {
+it('loads the given sources', async() => {
   const result = await loadConfig({
     sources: [
       {
@@ -26,6 +26,7 @@ it('load', async() => {
     merge: true,
   })
 
-  expect(result.config).toMatchSnapshot()
+  expect(result.config).toMatchSnapshot('config')
   expect(result.sources.length).toMatchSnapshot('files')
+  expect(result.sources.map(({ source }) => source)).toMatchSnapshot('sources')
 })


### PR DESCRIPTION
Note: this is a breaking change. 

This PR changes the returned `sources` property to return an array of objects containing both the filename and its transformed content instead of returning just the filename.

My use case for this was to perform analysis on the transformed code (original was TS code, I wanted the CJS result) - by analysis I mean finding the configuration's dependencies (to be able to refresh the config when they update).

I decided to transform the `sources` property because it made the most sense logically speaking, but I can rework this PR to return a third property so we avoid the breaking change.