### PR TITLE
fix: pass env param to config function

### DIFF
--- a/src/presets.ts
+++ b/src/presets.ts
@@ -12,13 +12,17 @@ export interface SourceObjectFieldOptions extends Omit<LoadConfigSource, 'rewrit
 
 export interface SourcePluginFactoryOptions extends Omit<LoadConfigSource, 'transform'>{
   targetModule: string
+  /**
+   * Parameters that passed to when the default export is a function
+   */
+  parameters?: any[]
 }
 
 /**
  * Rewrite the config file and extract the options passed to plugin factory
  * (e.g. Vite and Rollup plugins)
  */
-export function sourcePluginFactory(options: SourcePluginFactoryOptions, parameters: any[] = []) {
+export function sourcePluginFactory(options: SourcePluginFactoryOptions) {
   return {
     ...options,
     transform: (source: string) => {
@@ -32,7 +36,7 @@ __unconfig_stub.default = (data) => { __unconfig_data = data };
         .replace(new RegExp(`import (.+?) from (['"])${options.targetModule}\\2`), 'const $1 = __unconfig_stub;')
         .replace('export default', 'const __unconfig_default = ')
       if (code.includes('__unconfig_default'))
-        code += `\nif (typeof __unconfig_default === "function") __unconfig_default(...${JSON.stringify(parameters)});`
+        code += `\nif (typeof __unconfig_default === "function") __unconfig_default(...${JSON.stringify(options.parameters || [])});`
       return `${prefix}${code}${suffix}`
     },
   }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -14,11 +14,16 @@ export interface SourcePluginFactoryOptions extends Omit<LoadConfigSource, 'tran
   targetModule: string
 }
 
+interface ConfigEnv {
+  command: 'dev' | 'build' | 'serve'
+  mode?: string
+}
+
 /**
  * Retwrite the config file and extract the options passed to plugin factory
  * (e.g. Vite and Rollup plugins)
  */
-export function sourcePluginFactory(options: SourcePluginFactoryOptions) {
+export function sourcePluginFactory(options: SourcePluginFactoryOptions, env: ConfigEnv = { command: 'dev' }) {
   return {
     ...options,
     transform: (source: string) => {
@@ -32,7 +37,7 @@ __unconfig_stub.default = (data) => { __unconfig_data = data };
         .replace(new RegExp(`import (.+?) from (['"])${options.targetModule}\\2`), 'const $1 = __unconfig_stub;')
         .replace('export default', 'const __unconfig_default = ')
       if (code.includes('__unconfig_default'))
-        code += '\nif (typeof __unconfig_default === "function") __unconfig_default();'
+        code += `\nif (typeof __unconfig_default === "function") __unconfig_default(${JSON.stringify(env)});`
       return `${prefix}${code}${suffix}`
     },
   }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -14,16 +14,11 @@ export interface SourcePluginFactoryOptions extends Omit<LoadConfigSource, 'tran
   targetModule: string
 }
 
-interface ConfigEnv {
-  command: 'dev' | 'build' | 'serve'
-  mode?: string
-}
-
 /**
- * Retwrite the config file and extract the options passed to plugin factory
+ * Rewrite the config file and extract the options passed to plugin factory
  * (e.g. Vite and Rollup plugins)
  */
-export function sourcePluginFactory(options: SourcePluginFactoryOptions, env: ConfigEnv = { command: 'dev' }) {
+export function sourcePluginFactory(options: SourcePluginFactoryOptions, parameters: any[] = []) {
   return {
     ...options,
     transform: (source: string) => {
@@ -37,7 +32,7 @@ __unconfig_stub.default = (data) => { __unconfig_data = data };
         .replace(new RegExp(`import (.+?) from (['"])${options.targetModule}\\2`), 'const $1 = __unconfig_stub;')
         .replace('export default', 'const __unconfig_default = ')
       if (code.includes('__unconfig_default'))
-        code += `\nif (typeof __unconfig_default === "function") __unconfig_default(${JSON.stringify(env)});`
+        code += `\nif (typeof __unconfig_default === "function") __unconfig_default(...${JSON.stringify(parameters)});`
       return `${prefix}${code}${suffix}`
     },
   }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -4,10 +4,18 @@ import type { LoadConfigSource } from './types'
 
 export interface SourceVitePluginConfigOptions {
   plugins: Arrayable<string>
+  /**
+   * Parameters that passed to when the default export is a function
+   */
+  parameters?: any[]
 }
 
 export interface SourceObjectFieldOptions extends Omit<LoadConfigSource, 'rewrite'> {
   fields: Arrayable<string>
+  /**
+   * Parameters that passed to when the default export is a function
+   */
+  parameters?: any[]
 }
 
 export interface SourcePluginFactoryOptions extends Omit<LoadConfigSource, 'transform'>{
@@ -47,7 +55,7 @@ export function sourceVitePluginConfig(options: SourceVitePluginConfigOptions): 
   return {
     files: ['vite.config'],
     async rewrite(obj) {
-      const config = await (typeof obj === 'function' ? obj() : obj)
+      const config = await (typeof obj === 'function' ? obj(...options.parameters || [{ env: {} }, {}]) : obj)
       if (!config)
         return config
       return config.plugins.find((i: any) => plugins.includes(i.name) && i?.api?.config)?.api?.config
@@ -63,7 +71,7 @@ export function sourceObjectFields(options: SourceObjectFieldOptions): LoadConfi
   return {
     ...options,
     async rewrite(obj) {
-      const config = await (typeof obj === 'function' ? obj() : obj)
+      const config = await (typeof obj === 'function' ? obj(...options.parameters || []) : obj)
       if (!config)
         return config
       for (const field of fields) {

--- a/test/__snapshots__/run.test.ts.snap
+++ b/test/__snapshots__/run.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`load > files 1`] = `5`;
+exports[`load > files 1`] = `6`;
 
 exports[`load 1`] = `
 {
@@ -11,6 +11,7 @@ exports[`load 1`] = `
   "from": "package.json",
   "json": "allo",
   "mjs": "hi",
+  "param1": "include me",
   "rewrite": "Hi",
   "ts": "hello",
 }

--- a/test/fixtures/params.js
+++ b/test/fixtures/params.js
@@ -1,0 +1,10 @@
+import b from 'stub'
+
+export default (param1, { param2 }) => {
+  return {
+    plugin: b({
+      param1,
+    }),
+    param2,
+  }
+}

--- a/test/fixtures/rewrite.js
+++ b/test/fixtures/rewrite.js
@@ -1,7 +1,7 @@
 import a from 'stub'
 
-export default () => {
+export default ({ command }) => {
   return a({
-    rewrite: 'Hi',
+    rewrite: command === 'dev' ? 'Hi' : 'Bye',
   })
 }

--- a/test/fixtures/rewrite.js
+++ b/test/fixtures/rewrite.js
@@ -1,7 +1,7 @@
 import a from 'stub'
 
-export default ({ command }) => {
+export default () => {
   return a({
-    rewrite: command === 'dev' ? 'Hi' : 'Bye',
+    rewrite: 'Hi',
   })
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -20,7 +20,8 @@ it('load', async() => {
       sourcePluginFactory({
         targetModule: 'stub',
         files: 'params',
-      }, ['include me', { param2: 'but not me' }]),
+        parameters: ['include me', { param2: 'but not me' }],
+      }),
     ],
     cwd: resolve(__dirname, 'fixtures'),
     defaults: {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -17,6 +17,10 @@ it('load', async() => {
         files: 'rewrite.js',
         extensions: [],
       }),
+      sourcePluginFactory({
+        targetModule: 'stub',
+        files: 'params',
+      }, ['include me', { param2: 'but not me' }]),
     ],
     cwd: resolve(__dirname, 'fixtures'),
     defaults: {


### PR DESCRIPTION
I was tracing the root cause for the https://github.com/unocss/unocss/issues/874 and I think the problem is here:

https://github.com/antfu/unconfig/blob/be90fdb34230e924f1f773d12d15845edb1aa2b5/src/presets.ts#L35

A quick solution would be to pass an empty object to `__unconfig_default()` so the destructing would pass. I thought it would be better to make it configurable.

I did a little search and it sounds like the Rollup, Svelte, and Astro configs don't mind a parameter, so this should be safe to bypass the Vite special case.