### PR TITLE
refactor: remove `mlly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
   "dependencies": {
     "@antfu/utils": "^0.7.7",
     "defu": "^6.1.4",
-    "jiti": "^1.21.0",
-    "mlly": "^1.6.1"
+    "jiti": "^1.21.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.11.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       jiti:
         specifier: ^1.21.0
         version: 1.21.0
-      mlly:
-        specifier: ^1.6.1
-        version: 1.6.1
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.11.6
@@ -1816,6 +1813,7 @@ packages:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3276,6 +3274,7 @@ packages:
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: true
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -3512,6 +3511,7 @@ packages:
       pathe: 1.1.2
       pkg-types: 1.0.3
       ufo: 1.5.3
+    dev: true
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3735,6 +3735,7 @@ packages:
 
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
@@ -3764,6 +3765,7 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.6.1
       pathe: 1.1.2
+    dev: true
 
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -4253,6 +4255,7 @@ packages:
 
   /ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
+    dev: true
 
   /unbuild@2.0.0(typescript@5.4.3):
     resolution: {integrity: sha512-JWCUYx3Oxdzvw2J9kTAp+DKE8df/BnH/JTSj6JyA4SH40ECdFu7FoJJcrm8G92B7TjofQ6GZGjJs50TRxoH6Wg==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { promises as fs } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import process from 'node:process'
-import { interopDefault } from 'mlly'
 import jiti from 'jiti'
 import { notNullish, toArray } from '@antfu/utils'
 import defu from 'defu'
 import type { LoadConfigOptions, LoadConfigResult, LoadConfigSource } from './types'
 import { defaultExtensions } from './types'
 import { findUp } from './fs'
+import { interopDefault } from './interop'
 
 export * from './types'
 

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -1,0 +1,25 @@
+export function interopDefault<T>(mod: T & { default?: T }): T {
+  if (mod == null || typeof mod !== 'object' || !('default' in mod) || mod.default == null)
+    return mod
+
+  const defaultValue = mod.default
+
+  if (typeof defaultValue !== 'object')
+    return defaultValue
+
+  for (const key in mod) {
+    try {
+      if (!(key in defaultValue)) {
+        Object.defineProperty(defaultValue, key, {
+          enumerable: key !== 'default',
+          configurable: key !== 'default',
+          get() {
+            return (mod as any)[key]
+          },
+        })
+      }
+    }
+    catch {}
+  }
+  return defaultValue
+}


### PR DESCRIPTION
### Description

I was curious as to why the installation size of `unconfig` is an astonishing [3.2 MiB](https://pkg-size.dev/unconfig@0.3.12).

It turns out that `acorn`, an unused transitive dependency of `unconfig`, is introduced by `mlly`. `unconfig` only utilizes its `interopDefault` method.

Despite `mlly` being an excellent library, this PR aims to remove it from the `unconfig` dependency tree to decrease the installation size.

### Linked Issues

N/A

### Additional context

This is part of a series of PRs aiming to reduce [the installation size of `taze`](https://pkg-size.dev/taze@0.13.3), which is currently twice the size of `npm-check-updates`.