### PR TITLE
fix: normalize windows path when importing module

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -21,12 +21,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./presets": {
-      "types": "./dist/presets.d.ts",
       "import": "./dist/presets.mjs",
       "require": "./dist/presets.cjs"
     }
@@ -50,7 +48,7 @@
   "dependencies": {
     "@antfu/utils": "^0.7.8",
     "defu": "^6.1.4",
-    "importx": "^0.2.3"
+    "importx": "^0.2.4"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^6.1.4
         version: 6.1.4
       importx:
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.4
+        version: 0.2.4
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.18.0
@@ -1651,8 +1651,8 @@ packages:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
 
-  importx@0.2.3:
-    resolution: {integrity: sha512-crNS+2YOUsoF9ybRTTOb2Ciys9iNmR+fezfe8pIU+G0p5Ht+HN2DaIly7XSTpR8I0v9PCCN8DOzH7eJ+zJ7Wfw==}
+  importx@0.2.4:
+    resolution: {integrity: sha512-FldH9d+GsFzPAsyVrzvrkdGmXpysa4TRg5CyA4XCdKhMYk8s3H4JrlChoocAmzmeKzG7SmeYIO3NYWWFsvvfEQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4148,7 +4148,7 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  importx@0.2.3:
+  importx@0.2.4:
     dependencies:
       bundle-require: 4.1.0(esbuild@0.20.2)
       debug: 4.3.4


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR updates the types (removing types from package exports, CJS being masqueading as ESM):
![imagen](https://github.com/antfu/unconfig/assets/6311119/a3965d02-c654-4ddb-84c1-f965127db209)


### Linked Issues
NA

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
